### PR TITLE
Create map all at once instead of using repeated inserts when registering callbacks

### DIFF
--- a/type_dispatch/cmake/define_deserialize_benchmark.cmake
+++ b/type_dispatch/cmake/define_deserialize_benchmark.cmake
@@ -3,5 +3,5 @@ function(define_deserialize_benchmark BENCHMARK_NAME)
   target_include_directories(${BENCHMARK_NAME} PUBLIC
     "${CMAKE_SOURCE_DIR}/serialization/include"
     ${CEREAL_INCLUDE_DIRS} ${HANA_INCLUDE_DIRS} "../include")
-  target_compile_options(${BENCHMARK_NAME} PUBLIC "-std=c++1z" "-Wall")
+  target_compile_options(${BENCHMARK_NAME} PUBLIC "-std=c++1z" "-Wall" "-Os")
 endfunction()

--- a/type_dispatch/test/deserialize_casting.cpp
+++ b/type_dispatch/test/deserialize_casting.cpp
@@ -1,5 +1,6 @@
 #include "idl/ack.hpp"
 #include "idl/foo.hpp"
+#include "idl/bar.hpp"
 #include "idl/source.hpp"
 #include "deserialize_casting.hpp"
 
@@ -41,6 +42,18 @@ void foo_callback(void * args) {
   volatile Foo b = src;
 }
 
+void bar_callback(void * args) {
+  // User callbacks have to provide the message type and
+  // handle deserialization
+  auto archive = static_cast<cereal::BinaryOutputArchive *>(args);
+  if (!archive) {
+    return;
+  }
+  Bar src;
+  (*archive)(src);
+  volatile Bar b = src;
+}
+
 int main(int argc, char** argv) {
   std::stringstream s;
   cereal::BinaryOutputArchive a(s);
@@ -49,6 +62,7 @@ int main(int argc, char** argv) {
   register_callback("ack", ack_callback, callback_map);
   register_callback("source", source_callback, callback_map);
   register_callback("foo", foo_callback, callback_map);
+  register_callback("bar", bar_callback, callback_map);
 
   Ack ack;
   serialize_wrapper::serialize(ack, s);

--- a/type_dispatch/test/deserialize_meta.cpp
+++ b/type_dispatch/test/deserialize_meta.cpp
@@ -1,5 +1,6 @@
 #include "idl/ack.hpp"
 #include "idl/foo.hpp"
+#include "idl/bar.hpp"
 #include "idl/source.hpp"
 #include "deserialize_meta.hpp"
 
@@ -11,11 +12,12 @@ int main(int argc, char** argv) {
   std::stringstream s;
   cereal::BinaryOutputArchive a(s);
 
-  const auto [callback_map, type_sequence] = make_callback_registrar()
-    .register_callback<Ack>("ack", [](auto &&x){ volatile Ack y = x; })
-    .register_callback<Source>("source", [](auto &&x){ volatile Source y = x; })
-    .register_callback<Foo>("foo", [](auto &&x){ volatile Foo y = x; })
-    .unpack();
+  const auto [callback_map, type_sequence] = register_callbacks(
+    callback<Ack>("ack", [](auto &&x){ volatile Ack y = x; }),
+    callback<Source>("source", [](auto &&x){ volatile Source y = x; }),
+    callback<Foo>("foo", [](auto &&x){ volatile Foo y = x; }),
+    callback<Bar>("bar", [](auto &&x){ volatile Bar y = x; })
+  );
 
   Ack ack;
   serialize_wrapper::serialize(ack, s);


### PR DESCRIPTION
I just watched your CppCon talk (finally!), and saw that you were doing suspicious when inserting callbacks using Hana. With this PR, the code size for Hana-based callback registration is smaller than the other one.

The reason is that when you're inserting in a map, you're re-creating a new map and copying all the data over. This can cause code bloat because many functions are instantiated and not all the data shuffling will be optimized away. Whenever possible, it's better to create the structure all at once.

Also note that further improvement in code size can be achieved by using `-flto` (link time optimization).